### PR TITLE
feat: add recursive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Often, documents and books are being scanned two pages at a time. This tool allo
 Technically, you only have to provide the path for the input file. The tool will then split every page into two halves.
 You can skip pages (comma separated list) and you can shift the 'line' at which to cut. Positive values (0.1 to 49) will shift the line to the right (percantages of the width of the document) and negative values (-0.1 to -49) will shift the line to the left.
 
+### Directory splitting
+
+`python cli.py my_pdf_folder --recursive --recursive_suffix my_suffix --skip_pages 0,1 --shift_middle_percentage 0`
+
+To walk through a given directory and split every PDF within it and its subfolders, use the `--recursive` parameter. Since providing a specific output path is not possible here, you can define a custom suffix with `--recursive_suffix`. The output directory of the PDF will be the same as the input pdf.
+
 ## Creating a Binary
 
 The Windows binary was created using `pyinstaller` on Windows 10. If you want to create your own binary:

--- a/cli.py
+++ b/cli.py
@@ -1,5 +1,5 @@
 import click
-
+from pathlib import Path
 from pdf_split_middle import pdf_split_middle
 
 
@@ -8,10 +8,18 @@ from pdf_split_middle import pdf_split_middle
 @click.option('--pdf_output_path', default='split_middle.pdf', help='Path of the new PDF.')
 @click.option('--skip_pages', default='', help='A comma separated list of pages to skip.')
 @click.option('--shift_middle_percentage', default=0, help='Shift the split line. -49 to 49', type=float)
-def cli(pdf_path, pdf_output_path, skip_pages, shift_middle_percentage):
+@click.option('--recursive', is_flag=True, default=False, help='Walk through pdf_path directory')
+@click.option('--recursive_suffix', default='split', help='Suffix for output pdf file name when using recursive option')
 
-	skip_pages = skip_pages.split(',')
-	pdf_split_middle(pdf_path, pdf_output_path, skip_pages, shift_middle_percentage)
+def cli(pdf_path, pdf_output_path, skip_pages, shift_middle_percentage, recursive, recursive_suffix):
+    skip_pages = skip_pages.split(',')
+    if recursive:
+        for path in Path(pdf_path).rglob('*'):
+            if path.suffix.lower() == '.pdf':
+                output_path = f'{path.parent}/{path.stem}_{recursive_suffix}{path.suffix}'
+                pdf_split_middle(path, output_path, skip_pages, shift_middle_percentage)
+    else:
+        pdf_split_middle(pdf_path, pdf_output_path, skip_pages, shift_middle_percentage)
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
Hi there, thanks for the neat little tool! I've extended it for a use case of mine and introduced a flag to recursively walk directories and split every PDF within. I've also added a `--recursive_suffix` option, since defining a single output path is not viable here.